### PR TITLE
Fix: make use of listTitle to avoid hardcoding header

### DIFF
--- a/src/components/ui/ArticleList.astro
+++ b/src/components/ui/ArticleList.astro
@@ -10,7 +10,7 @@ interface Props {
 const {listTitle, listItems} = Astro.props
 ---
 
-<h2 class='text-3xl font-bold mb-8'>Recent Publications</h2>
+<h2 class='text-3xl font-bold mb-8'>{listTitle}</h2>
 		<div class='space-y-6'>
 			{
 				listItems.map(item => (


### PR DESCRIPTION
I noticed that "Recent Publications" was being hardcoded in the ArticleList `<h2>` element, despite being passed through in props.